### PR TITLE
Feature: On a credit Invoice I wanted to get the original invoice ref…

### DIFF
--- a/FortnoxAPILibrary/Entities/Invoices/Invoice.cs
+++ b/FortnoxAPILibrary/Entities/Invoices/Invoice.cs
@@ -214,6 +214,11 @@ namespace FortnoxAPILibrary.Entities
         [JsonProperty]
         public DateTime? InvoicePeriodEnd { get; private set; }
 
+        ///<summary>Reference to the invoice, if one exits. The reference must be a document number for an existing invoice </summary>
+        [ReadOnly]
+        [JsonProperty]
+        public long? InvoiceReference { get; private set; }
+
         ///<summary> The properties for the object in this array is listed in the table “Invoice Rows”. </summary>
         [JsonProperty]
         public List<InvoiceRow> InvoiceRows { get; set; }


### PR DESCRIPTION
…erence. Is was not the property CreditInvoiceReference as i first expected, when analyzing the JSON for the Invoice it seems to be present in the missing InvoiceReference property. This property is not listed in the API documentation so I don't know if it is read-only or not, but CreditInvoiceReference is read-only so I went for this option.