### PR TITLE
fix: Golden EDI specific fix for rate limit based on that we have two…

### DIFF
--- a/FortnoxSDK/Connectors/Base/RateLimiter.cs
+++ b/FortnoxSDK/Connectors/Base/RateLimiter.cs
@@ -11,8 +11,8 @@ namespace Fortnox.SDK.Connectors.Base;
 /// </summary>
 internal class RateLimiter
 {    
-    private const int MaxCount = 4;
-    private static readonly TimeSpan Period = TimeSpan.FromSeconds(1);
+    private const int MaxCount = 12;
+    private static readonly TimeSpan Period = TimeSpan.FromSeconds(5);
     
     private static readonly Dictionary<string, TimeLimiter> RateLimiters = new();
 


### PR DESCRIPTION
… data centers (The Fortnox limit seems to be 25 requests on 5 seconds so we are using half of that)